### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import * as React from "react";
+
+type Carbonbadge = React.FC<{
+    // Whether the badge should be in dark mode
+    darkMode?: boolean;
+}>;
+
+declare const carbonbadge: Carbonbadge;
+
+export default carbonbadge;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/ivoba/react-carbonbadge",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "author": "Ivo Bathke",
   "scripts": {


### PR DESCRIPTION
Hi there! I think the work that is being done with Website Carbon and the Carbon Badge is pretty cool. I'm including it with a website for a new project I'm doing in Typescript, but I found the typescript definitions were missing for this package, so I've added them.

Cheers for the good work!